### PR TITLE
Add option to modify merge delimiter for duplicate nodes

### DIFF
--- a/cat_merge/merge.py
+++ b/cat_merge/merge.py
@@ -8,7 +8,7 @@ def merge(
     edges: List[str] = None,#typer.Option(None, help="Optional list of edge files"),
     nodes: List[str] = None,#typer.Option(None, help="Optional list of node files"),
     output_dir: str = "merged-output",#typer.Option("merged-output", help="Directory to output knowledge graph")
-    merge_delimiter: str = " ",#typer.Option(" ", help="Delimiter to use when merging categories and properties on duplicates")
+    merge_delimiter: str = "|",#typer.Option("|", help="Delimiter to use when merging categories and properties on duplicates")
     ):
 
     print(f"Merging KG files...\nName: {name} // input_dir: {input_dir} // nodes: {nodes} // edges: {edges} // output_dir: {output_dir}")

--- a/cat_merge/merge.py
+++ b/cat_merge/merge.py
@@ -7,7 +7,8 @@ def merge(
     input_dir: str = None,#typer.Option(None, help="Optional directory containing node and edge files"),
     edges: List[str] = None,#typer.Option(None, help="Optional list of edge files"),
     nodes: List[str] = None,#typer.Option(None, help="Optional list of node files"),
-    output_dir: str = "merged-output",#typer.Option("merge-output", help="Directory to output knowledge graph")
+    output_dir: str = "merged-output",#typer.Option("merged-output", help="Directory to output knowledge graph")
+    merge_delimiter: str = " ",#typer.Option(" ", help="Delimiter to use when merging categories and properties on duplicates")
     ):
 
     print(f"Merging KG files...\nName: {name} // input_dir: {input_dir} // nodes: {nodes} // edges: {edges} // output_dir: {output_dir}")
@@ -22,6 +23,6 @@ def merge(
 
     write(
         name=name,
-        kg=merge_kg(node_dfs=node_dfs, edge_dfs=edge_dfs),
+        kg=merge_kg(node_dfs=node_dfs, edge_dfs=edge_dfs, merge_delimiter=merge_delimiter),
         output_dir=output_dir
     )

--- a/cat_merge/merge_utils.py
+++ b/cat_merge/merge_utils.py
@@ -13,12 +13,12 @@ def get_duplicate_rows(df: DataFrame) -> DataFrame:
     return df[df.index.duplicated(keep=False)]
 
 
-def clean_nodes(nodes: DataFrame) -> DataFrame:
+def clean_nodes(nodes: DataFrame, merge_delimiter: str) -> DataFrame:
     nodes.reset_index(inplace=True)
     nodes.drop_duplicates(inplace=True)
     nodes = nodes.rename(columns={'index': 'id'})
     nodes.fillna("None", inplace=True)
-    column_agg = {x: ' '.join for x in nodes.columns if x != 'id'}
+    column_agg = {x: merge_delimiter.join for x in nodes.columns if x != 'id'}
     nodes = nodes.groupby(['id'], as_index=True).agg(column_agg)
     return nodes
 
@@ -31,7 +31,7 @@ def get_dangling_edges(edges: DataFrame, nodes: DataFrame) -> DataFrame:
     return edges[~edges.subject.isin(nodes.index) | ~edges.object.isin(nodes.index)]
 
 
-def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame]) -> MergedKG:
+def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame], merge_delimiter: str) -> MergedKG:
 
     all_nodes = concat_dataframes(node_dfs)
     all_edges = concat_dataframes(edge_dfs)
@@ -39,7 +39,7 @@ def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame]) -> MergedKG:
     duplicate_nodes = get_duplicate_rows(df=all_nodes)
     dangling_edges = get_dangling_edges(edges=all_edges, nodes=all_nodes)
 
-    nodes = clean_nodes(nodes=all_nodes)
+    nodes = clean_nodes(nodes=all_nodes, merge_delimiter=merge_delimiter)
     edges = clean_edges(edges=all_edges, nodes=nodes)
 
     return MergedKG(nodes=nodes, edges=edges, duplicate_nodes=duplicate_nodes, dangling_edges=dangling_edges)

--- a/cat_merge/merge_utils.py
+++ b/cat_merge/merge_utils.py
@@ -31,7 +31,7 @@ def get_dangling_edges(edges: DataFrame, nodes: DataFrame) -> DataFrame:
     return edges[~edges.subject.isin(nodes.index) | ~edges.object.isin(nodes.index)]
 
 
-def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame], merge_delimiter: str = " ") -> MergedKG:
+def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame], merge_delimiter: str = "|") -> MergedKG:
 
     all_nodes = concat_dataframes(node_dfs)
     all_edges = concat_dataframes(edge_dfs)

--- a/cat_merge/merge_utils.py
+++ b/cat_merge/merge_utils.py
@@ -13,7 +13,7 @@ def get_duplicate_rows(df: DataFrame) -> DataFrame:
     return df[df.index.duplicated(keep=False)]
 
 
-def clean_nodes(nodes: DataFrame, merge_delimiter: str) -> DataFrame:
+def clean_nodes(nodes: DataFrame, merge_delimiter: str = " ") -> DataFrame:
     nodes.reset_index(inplace=True)
     nodes.drop_duplicates(inplace=True)
     nodes = nodes.rename(columns={'index': 'id'})
@@ -31,7 +31,7 @@ def get_dangling_edges(edges: DataFrame, nodes: DataFrame) -> DataFrame:
     return edges[~edges.subject.isin(nodes.index) | ~edges.object.isin(nodes.index)]
 
 
-def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame], merge_delimiter: str) -> MergedKG:
+def merge_kg(edge_dfs: List[DataFrame], node_dfs: List[DataFrame], merge_delimiter: str = " ") -> MergedKG:
 
     all_nodes = concat_dataframes(node_dfs)
     all_edges = concat_dataframes(edge_dfs)


### PR DESCRIPTION
This is an additional arg for `merge` - it just specifies what char(s) to have `clean_nodes()` use when aggregating columns.
Ex:
```
merge(name='test',nodes=['bfo_kgx_tsv_nodes.tsv','bfo_kgx_tsv_nodes2.tsv'],edges=['bfo_kgx_tsv_edges.tsv'], merge_delimiter="*")
```