### PR TITLE
Fixed mappings apply function, refactored index vs id

### DIFF
--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -25,13 +25,8 @@ def read_dfs(files: List[str], add_provided_by: bool = True) -> List[pd.DataFram
     return dataframes
 
 
-def read_df(file: str, add_provided_by: bool = True, index_column_is_id: bool = True):
-
-    if index_column_is_id:
-        df = pd.read_csv(file, sep="\t", dtype="string", lineterminator="\n", index_col='id', quoting=csv.QUOTE_NONE)
-        df.index.name = 'id'
-    else:
-        df = pd.read_csv(file, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE)
+def read_df(file: str, add_provided_by: bool = True):
+    df = pd.read_csv(file, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE)
 
     if add_provided_by:
         df["provided_by"] = os.path.basename(file)
@@ -39,7 +34,7 @@ def read_df(file: str, add_provided_by: bool = True, index_column_is_id: bool = 
 
 
 def write_df(df: pd.DataFrame, filename: str):
-    df.to_csv(filename, sep="\t")
+    df.to_csv(filename, sep="\t", index=False)
 
 
 def write_tar(tar_path: str, files: List[str], delete_files=True):

--- a/cat_merge/mapping_utils.py
+++ b/cat_merge/mapping_utils.py
@@ -4,14 +4,18 @@ from pandas.core.frame import DataFrame
 
 def apply_mappings(edges: DataFrame, mapping: DataFrame):
 
-    mapping_dict = mapping.set_index('subject_id')['object_id']
-
-    edges['original_subject'] = edges['subject']
-    edges['subject'].replace(mapping_dict, inplace=True)
+    edges.rename(columns={'subject':'original_subject'}, inplace=True)
+    subject_mapping = mapping.rename(columns={'object_id':'subject'})
+    subject_mapping = subject_mapping[["subject","subject_id"]]
+    edges = edges.merge(subject_mapping, how='left', left_on='original_subject', right_on='subject_id').drop(['subject_id'],axis=1)
+    edges['subject'] = np.where(edges.subject.isnull(), edges.original_subject, edges.subject)
     edges['original_subject'] = np.where(edges.subject == edges.original_subject, None, edges.original_subject)
 
-    edges['original_object'] = edges['object']
-    edges['object'].replace(mapping_dict, inplace=True)
+    edges.rename(columns={'object':'original_object'}, inplace=True)
+    object_mapping = mapping.rename(columns={'object_id':'object'})
+    object_mapping = object_mapping[["object", "subject_id"]]
+    edges = edges.merge(object_mapping, how='left', left_on='original_object', right_on='subject_id').drop(['subject_id'],axis=1)
+    edges['object'] = np.where(edges.object.isnull(), edges.original_object, edges.object)
     edges['original_object'] = np.where(edges.object == edges.original_object, None, edges.original_object)
 
     return edges

--- a/cat_merge/merge.py
+++ b/cat_merge/merge.py
@@ -45,7 +45,7 @@ Merging KG files...
 
     mapping_df = None
     if mapping is not None:
-        mapping_df = read_df(mapping, index_column_is_id=False)
+        mapping_df = read_df(mapping, add_provided_by=False)
 
     print("Merging...")
     kg = merge_kg(node_dfs=node_dfs, edge_dfs=edge_dfs, mapping=mapping_df, merge_delimiter=merge_delimiter)

--- a/cat_merge/merge_utils.py
+++ b/cat_merge/merge_utils.py
@@ -9,24 +9,23 @@ def concat_dataframes(dataframes: List[DataFrame]) -> DataFrame:
 
 
 def get_duplicate_rows(df: DataFrame) -> DataFrame:
-    return df[df.index.duplicated(keep=False)]
+    return df[df.id.duplicated(keep=False)]
 
 
 def clean_nodes(nodes: DataFrame, merge_delimiter: str = " ") -> DataFrame:
-    nodes.reset_index(inplace=True)
-    nodes.drop_duplicates(inplace=True)
-    nodes = nodes.rename(columns={'index': 'id'})
-    column_agg = {x: merge_delimiter.join for x in nodes.columns if x != 'id'}
-    nodes = nodes.groupby(['id'], as_index=True).agg(column_agg)
+    # TODO: id column isn't coming out of this
+    # nodes.drop_duplicates(inplace=True)
+    # column_agg = {x: merge_delimiter.join for x in nodes.columns if x != 'id'}
+    # nodes = nodes.groupby(['id']).agg(column_agg)
     return nodes
 
 
 def clean_edges(edges: DataFrame, nodes: DataFrame) -> DataFrame:
-    return edges[edges.subject.isin(nodes.index) & edges.object.isin(nodes.index)]
+    return edges[edges.subject.isin(nodes.id) & edges.object.isin(nodes.id)]
 
 
 def get_dangling_edges(edges: DataFrame, nodes: DataFrame) -> DataFrame:
-    dangling_edges = edges[~edges.subject.isin(nodes.index) | ~edges.object.isin(nodes.index)]
+    dangling_edges = edges[~edges.subject.isin(nodes.id) | ~edges.object.isin(nodes.id)]
     return dangling_edges
 
 

--- a/cat_merge/merge_utils.py
+++ b/cat_merge/merge_utils.py
@@ -13,10 +13,7 @@ def get_duplicate_rows(df: DataFrame) -> DataFrame:
 
 
 def clean_nodes(nodes: DataFrame, merge_delimiter: str = " ") -> DataFrame:
-    # TODO: id column isn't coming out of this
-    # nodes.drop_duplicates(inplace=True)
-    # column_agg = {x: merge_delimiter.join for x in nodes.columns if x != 'id'}
-    # nodes = nodes.groupby(['id']).agg(column_agg)
+    nodes.drop_duplicates(inplace=True)
     return nodes
 
 

--- a/cat_merge/qc_utils.py
+++ b/cat_merge/qc_utils.py
@@ -88,20 +88,7 @@ def create_qc_report(merged_kg: MergedKG) -> Dict:
     nodes['in_taxon'] = nodes['in_taxon'].fillna('missing taxon')
     nodes['category'] = nodes['category'].fillna('missing category')
 
-    # convert the index back into an id column for nodes
-    nodes.reset_index(inplace=True)
-    nodes = nodes.rename(columns={'index': 'id'})
-
     unique_id_from_nodes = nodes["id"]
-
-    # convert the index back into an id column for edges
-    edges.reset_index(inplace=True)
-    edges = edges.rename(columns={'index': 'id'})
-
-    # convert the index back into an id column for dangling_edges
-    dangling_edges.reset_index(inplace=True)
-    dangling_edges = dangling_edges.rename(columns={'index': 'id'})
-
 
     ingest_collection = {
         "edges": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cat-merge"
-version = "0.1.11"
+version = "0.1.12"
 description = ""
 authors = [
     "Monarch Initiative <info@monarchinitiative.org>",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,15 @@
 import pandas as pd
 from io import StringIO
+from pandas.core.frame import DataFrame
 
 
 # Borrowed from https://stackoverflow.com/questions/58771331/cleanly-hard-code-a-pandas-dataframe-into-a-python-script
 def string_df(data: str, index_column_is_id=True):
     if index_column_is_id:
-        df = pd.read_csv(StringIO(data), index_col='id', sep=r"\s+", engine='python')
+        df = pd.read_csv(StringIO(data), sep=r"\s+", engine='python')
     else:
         df = pd.read_csv(StringIO(data), sep=r"\s+", engine='python')
     return df
+
+def value(df: DataFrame, id: str, column: str):
+    return list(df.loc[df['id'] == id][column])[0]

--- a/tests/unit/test_concat_dataframe.py
+++ b/tests/unit/test_concat_dataframe.py
@@ -29,8 +29,7 @@ def test_length(dataframes):
 
 def test_columns(dataframes):
     df = concat_dataframes(list(dataframes))
-    assert(df.index.name == 'id')
-    assert(list(df.columns) == ['category', 'name', 'xrefs', 'synonyms'])
+    assert(list(df.columns) == ['id', 'category', 'name', 'xrefs', 'synonyms'])
 
 
 @pytest.fixture
@@ -56,5 +55,4 @@ def test_empty_df(one_empty_dataframe):
 def test_null_dataframe(dataframes):
     df = concat_dataframes([dataframes[0], None])
     assert(len(df) == 2)
-    assert(df.index.name == 'id')
-    assert(list(df.columns) == ['category', 'name', 'xrefs'])
+    assert(list(df.columns) == ['id', 'category', 'name', 'xrefs'])

--- a/tests/unit/test_get_dangling_edges.py
+++ b/tests/unit/test_get_dangling_edges.py
@@ -33,9 +33,11 @@ def test_get_dangling_edges(nodes_and_edges):
 
     assert(len(dangling_edges) == 3)
 
-    assert('uuid:1' not in dangling_edges.index)
-    assert('uuid:2' not in dangling_edges.index)
-    assert('uuid:3' in dangling_edges.index)
-    assert('uuid:4' in dangling_edges.index)
-    assert('uuid:5' in dangling_edges.index)
+    dangling_edge_ids = list(dangling_edges.id)
+
+    assert('uuid:1' not in dangling_edge_ids)
+    assert('uuid:2' not in dangling_edge_ids)
+    assert('uuid:3' in dangling_edge_ids)
+    assert('uuid:4' in dangling_edge_ids)
+    assert('uuid:5' in dangling_edge_ids)
 

--- a/tests/unit/test_get_duplicate_rows.py
+++ b/tests/unit/test_get_duplicate_rows.py
@@ -20,5 +20,5 @@ def dataframe_with_duplicates() -> DataFrame:
 def test_get_duplicate_row(dataframe_with_duplicates):
     df = get_duplicate_rows(dataframe_with_duplicates)
     assert(len(df) == 2)
-    assert(list(df.index) == ["Gene:2", "Gene:2"])
+    assert(list(df.id) == ["Gene:2", "Gene:2"])
 


### PR DESCRIPTION
The first attempt at applying mappings passed the test, but it was way too slow - this seems to be working much better with a pandas join.

A side effect of this was that I had to really deal with the funky state of the code wrt whether the id field was the index of the data frame - I like the idea, but if doesn't get used in a merge, what good does it do?  so I simplified things quite a bit by letting there be an index independent of the id and just not writing the index. 

This made it slightly tougher to get values out during testing, and the id wasn't retained during the node merging. Rather than look at solving that, it made more sense to me to remove node merging. I think fundamentally this codebase isn't intended for graphs that don't follow monarch-ingest style design guidelines of taking nodes only from single authoritative sources.