### PR TITLE
Create qc report from kg tar archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Python library for merging individual source KGX files in the Monarch Initiative
 #### Dependencies
 
 - [Poetry](https://python-poetry.org/docs/)
+- [Pandas](https://pandas.pydata.org/)
 
 #### Usage
 

--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -2,7 +2,7 @@ import csv
 import os, tarfile
 from pathlib import Path
 import pandas as pd
-from typing import List, Tuple
+from typing import List, Optional
 
 from cat_merge.model.merged_kg import MergedKG
 
@@ -45,6 +45,20 @@ def write_tar(tar_path: str, files: List[str], delete_files=True):
     if delete_files:
         for file in files:
             os.remove(file)
+
+def read_kg(archive_path: str,
+            dangling_edges_path: Optional[str],
+            nodes_file_name: Optional[str],
+            edges_file_name: Optional[str]) -> MergedKG:
+    if not os.path.exists(archive_path):
+        raise FileNotFoundError
+    if dangling_edges is not None and not os.path.exists(dangling_edges_path)
+        raise FileNotFoundError
+
+    # iterate over files in tar, pull _nodes and _edges
+
+    # read into pandas and return a MergedKG instance
+
 
 
 def write(kg: MergedKG, name: str, output_dir: str):

--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -46,20 +46,52 @@ def write_tar(tar_path: str, files: List[str], delete_files=True):
         for file in files:
             os.remove(file)
 
+
+
+def read_tar_dfs(tar: tarfile.TarFile, add_provided_by: bool = True) -> List[pd.DataFrame]:
+    dataframes = []
+    for member in tar.getmembers():
+        info = tar.extractfile(member)
+        if info:
+            dataframes.append(read_tar_df(info, add_provided_by=add_provided_by))
+    return dataframes
+
+def read_tar_df(info: tarfile.TarInfo, add_provided_by: bool = True, provided_by: str = None):
+    df = pd.read_csv(info, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE, comment='#')
+
+    if add_provided_by:
+        df["provided_by"] = provided_by
+    return df
+
+
+def read_tar_dfs_2(tar: tarfile.TarFile, add_provided_by: bool = True) -> List[pd.DataFrame]:
+    dataframes = []
+    for member in tar.getmembers():
+        f = tar.extractfile(member)
+        if f:
+            dataframes.append(read_tar_df(f, add_provided_by = add_provided_by, provided_by = member.name))
+                # pd.read_csv(f, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE, comment='#'))
+    return dataframes
+
+
 def read_kg(archive_path: str,
-            dangling_edges_path: Optional[str],
-            nodes_file_name: Optional[str],
-            edges_file_name: Optional[str]) -> MergedKG:
+            add_provided_by: bool = True,
+            # dangling_edges: bool = True,
+            # dangling_edges_path: str = None,
+            nodes_file_name: str = None,
+            edges_file_name: str = None):
     if not os.path.exists(archive_path):
         raise FileNotFoundError
-    if dangling_edges is not None and not os.path.exists(dangling_edges_path)
-        raise FileNotFoundError
+    # if dangling_edges is not None and not os.path.exists(dangling_edges_path):
+    #     raise FileNotFoundError
 
     # iterate over files in tar, pull _nodes and _edges
+    tar = tarfile.open(archive_path, "r:*")
+    dataframes = read_tar_dfs_2(tar, add_provided_by=add_provided_by)
 
     # read into pandas and return a MergedKG instance
 
-
+    return dataframes
 
 def write(kg: MergedKG, name: str, output_dir: str):
 

--- a/cat_merge/qc.py
+++ b/cat_merge/qc.py
@@ -1,0 +1,2 @@
+
+def qc(kg_archive: str, dangling_edges: str):

--- a/cat_merge/qc.py
+++ b/cat_merge/qc.py
@@ -1,2 +1,20 @@
+import yaml
+import logging
 
-def qc(kg_archive: str, dangling_edges: str):
+from cat_merge.file_utils import read_kg
+from cat_merge.qc_utils import create_qc_report
+
+def qc_report(archive_path: str,
+              output_dir: str,
+              output_name: str = "qc_report.yaml",
+              add_provided_by: bool = True,
+              # dangling_edges: bool = True,
+              # dangling_edges_path: str = None,
+              nodes_file_name: str = None,
+              edges_file_name: str = None):
+    kg = read_kg(archive_path)
+
+    qc_report = create_qc_report(kg)
+
+    with open(f"{output_dir}/{output_name}", "w") as report_file:
+        yaml.dump(qc_report, report_file)


### PR DESCRIPTION
I've completed the kg_reader function to allow us to read from archives and used the create_qc_report funciton to create a report after we have done so. No we can get to tweaking the report and test easily.

@putmantime and @kevinschaper please let me know what you think. Specifically, I'm concerned about importing merge_kg form cat_merge.merge_utils because this could create circular dependencies if we're not careful. However, duplicating that code also seems foolish.