### PR TITLE
Simplify QC and guarantee predictable order

### DIFF
--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -3,7 +3,9 @@ import os
 import tarfile
 from pathlib import Path
 import pandas as pd
-from typing import List, IO, Union, Optional
+from typing import IO, List, Optional, Tuple, Union
+
+from pandas import DataFrame
 
 from cat_merge.model.merged_kg import MergedKG
 
@@ -43,14 +45,14 @@ def read_df(fh: Union[str, IO[bytes]],
     return df
 
 
-def read_tar(archive_path: str,
-             nodes_match: str = "_nodes",
-             edges_match: str = "_edges",
-             add_source_col: str = "provided_by"):
-    tar = tarfile.open(archive_path, "r:*")
-    node_dfs = read_tar_dfs(tar, nodes_match, add_source_col)
-    edge_dfs = read_tar_dfs(tar, edges_match, add_source_col)
-    return node_dfs, edge_dfs
+# def read_tar(archive_path: str,
+#              nodes_match: str = "_nodes",
+#              edges_match: str = "_edges",
+#              add_source_col: str = "provided_by"):
+#     tar = tarfile.open(archive_path, "r:*")
+#     node_dfs = read_tar_dfs(tar, nodes_match, add_source_col)
+#     edge_dfs = read_tar_dfs(tar, edges_match, add_source_col)
+#     return node_dfs, edge_dfs
 
 
 def write_df(df: pd.DataFrame, filename: str):
@@ -70,30 +72,47 @@ def write_tar(tar_path: str, files: List[str], delete_files=True):
 def read_kg(source: str = None,
             node_match: str = "_node",
             edge_match: str = "_edge",
+            duplicate_node_match: str = "duplicate-node",
+            dangling_edge_match: str = "dangling-edge",
             node_file: str = None,
             edge_file: str = None,
+            duplicate_node_file: str = None,
+            dangling_edge_file: str = None,
             add_source_col: str = None) -> MergedKG:
-    # TODO implement duplicate_nodes and dangling_edges
+    duplicate_nodes = []
+    dangling_edges = []
 
-    # This section is very similar to "reading nodes and edge files" section of merge()
-    # These should probably be extracted into a single get_ function
-
-    if node_file is not None and edge_file is not None:
-        nodes = read_df(node_file, add_source_col, node_file)
-        edges = read_df(edge_file, add_source_col, node_file)
-    elif source is not None:
-        if os.path.isdir(source):
+    if source is not None:
+        if node_file is not None or edge_file is not None \
+                or duplicate_node_file is not None or dangling_edge_file is not None:
+            raise ValueError("Wrong attributes: source and files cannot both be specified")
+        elif os.path.isdir(source):
             [node_file], [edge_file] = get_files(source)
             nodes = read_df(node_file, add_source_col, node_file)
             edges = read_df(edge_file, add_source_col, edge_file)
+            [duplicate_node_file], [dangling_edge_file] = get_files(source, duplicate_node_match, dangling_edge_match)
+            duplicate_nodes = read_df(duplicate_node_file, add_source_col, node_file)
+            dangling_edges = read_df(dangling_edge_file, add_source_col, node_file)
         elif tarfile.is_tarfile(source):
-            [nodes], [edges] = read_tar(source, node_match, edge_match, add_source_col)
+            tar = tarfile.open(source, "r:*")
+            [nodes] = read_tar_dfs(tar, node_match, add_source_col)
+            [edges] = read_tar_dfs(tar, edge_match, add_source_col)
+            [duplicate_nodes] = read_tar_dfs(tar, edge_match, add_source_col)
+            [dangling_edges] = read_tar_dfs(tar, edge_match, add_source_col)
+            # [nodes], [edges] = read_tar(source, node_match, edge_match, add_source_col)
         else:
-            ValueError("source is not an archive or directory")
+            raise ValueError("source is not an archive or directory")
+    elif node_file is not None and edge_file is not None:
+        nodes = read_df(node_file, add_source_col, node_file)
+        edges = read_df(edge_file, add_source_col, node_file)
+        if duplicate_node_file is not None:
+            duplicate_nodes = read_df(duplicate_node_file, add_source_col, node_file)
+        if dangling_edge_file is not None:
+            dangling_edges = read_df(dangling_edge_file, add_source_col, node_file)
     else:
         raise ValueError("Must specify either nodes & edges or source")
 
-    kg = MergedKG(nodes, edges, pd.DataFrame(), pd.DataFrame())
+    kg = MergedKG(nodes, edges, duplicate_nodes, dangling_edges)
     return kg
 
 

--- a/cat_merge/merge.py
+++ b/cat_merge/merge.py
@@ -29,6 +29,8 @@ Merging KG files...
   mappings: {mappings}
   output_dir: {output_dir}
 """)
+    if source is not None and nodes is not None:
+        raise ValueError("Wrong attributes: source and node/edge files cannot both be specified")
 
     print("Reading node and edge files")
     if type(nodes) is list and len(nodes) > 0 \
@@ -41,9 +43,12 @@ Merging KG files...
             node_dfs = read_dfs(node_files)
             edge_dfs = read_dfs(edge_files)
         elif tarfile.is_tarfile(source):
-            node_dfs, edge_dfs = read_tar(source)
+            tar = tarfile.open(source, "r:*")
+            node_dfs = read_tar_dfs(tar, "_nodes")
+            edge_dfs = read_tar_dfs(tar, "_edges")
+            # node_dfs, edge_dfs = read_tar(source)
         else:
-            ValueError("Specified source is not a directory or tar archive")
+            raise ValueError("Specified source is not a directory or tar archive")
     else:
         raise ValueError("Must specify either nodes & edges as lists or source as a directory or tar archive")
 

--- a/cat_merge/qc_utils.py
+++ b/cat_merge/qc_utils.py
@@ -7,13 +7,21 @@ from typing import Dict, List
 def create_edge_report(edges_provided_by, edges_provided_by_values, unique_id_from_nodes) -> Dict:
     edge_object = {
         "name": edges_provided_by,
-        "namespaces": list(set((list(set(edges_provided_by_values['subject'].str.split(':').str[0]))) + (list(set(
-            edges_provided_by_values['object'].str.split(':').str[0]))))),
-        "categories": list(set(edges_provided_by_values['category'])),
-        "total_number": len(edges_provided_by_values['id'].tolist()),
+        "namespaces": col_to_yaml(get_namespace(
+            pd.concat([edges_provided_by_values['subject'], edges_provided_by_values['object']])
+        ).drop_duplicates()),
+        # "namespaces": list(set((list(set(edges_provided_by_values['subject'].str.split(':').str[0]))) + (list(set(
+        #     edges_provided_by_values['object'].str.split(':').str[0]))))),
+        "categories": col_to_yaml(edges_provided_by_values['category']),
+        "total_number": edges_provided_by_values['id'].size,
         # unique subjects and objects in edges but not in unique id nodes file
-        "missing": (len(set(edges_provided_by_values['subject']) - set(unique_id_from_nodes))) + (len(set(
-            edges_provided_by_values['object']) - set(unique_id_from_nodes))),
+        "missing": get_missing(
+            [edges_provided_by_values['subject'], edges_provided_by_values['object']], unique_id_from_nodes),
+        # "missing": list_difference(pd.concat(
+        #     [edges_provided_by_values['subject'], edges_provided_by_values['object']]
+        # ).drop_duplicates().sort_values().tolist(), unique_id_from_nodes.tolist()),
+        # "missing": (len(set(edges_provided_by_values['subject']) - set(unique_id_from_nodes))) + (len(set(
+        #     edges_provided_by_values['object']) - set(unique_id_from_nodes))),
         "predicates": [],
         "node_types": []
     }
@@ -27,23 +35,27 @@ def create_predicate_report(edges_provided_by_values, unique_id_from_nodes) -> L
     for predicate, predicate_values in predicate_group:
         predicate_object = {
             "uri": predicate,
-            "total_number": len(predicate_values['id'].tolist()),
+            "total_number": predicate_values['id'].size,
             "missing_subjects": len(set(predicate_values['subject']) - set(unique_id_from_nodes)),
             "missing_objects": len(set(predicate_values['object']) - set(unique_id_from_nodes)),
-            "missing_subject_namespaces": list(
-                set([x.split(":")[0] for x in (set(predicate_values['subject']) - set(unique_id_from_nodes))])),
-            "missing_object_namespaces": list(
-                set([x.split(":")[0] for x in (set(predicate_values['object']) - set(unique_id_from_nodes))]))
+            "missing_subject_namespaces": col_to_yaml(get_namespace(series_difference(
+                predicate_values['subject'], unique_id_from_nodes))),
+            # list(set([x.split(":")[0] for x in (set(predicate_values['subject']) - set(unique_id_from_nodes))])),
+            "missing_object_namespaces": col_to_yaml(get_namespace(series_difference(
+                predicate_values['object'], unique_id_from_nodes))),
+            # list(set([x.split(":")[0] for x in (set(predicate_values['object']) - set(unique_id_from_nodes))]))
         }
         predicates.append(predicate_object)
     return predicates
 
 
-def create_edge_node_types_report(edges_provided_by_values, unique_id_from_nodes, nodes):
+def create_edge_node_types_report(edges_provided_by_values, nodes) -> List[Dict]:
     node_types = []
     # list of subjects and objects from edges file that are in nodes file
-    node_type_list = (list(set(edges_provided_by_values['subject']) & set(unique_id_from_nodes))) + (list(set(
-        edges_provided_by_values['object']) & set(unique_id_from_nodes)))
+    node_type_list = list_intersect(edges_provided_by_values['subject'], nodes["id"]) \
+                     + list_intersect(edges_provided_by_values['object'], nodes["id"]),
+    # (list(set(edges_provided_by_values['subject']) & set(nodes["id"]))) + (list(set(
+    #     edges_provided_by_values['object']) & set(nodes["id"])))
     node_type_df = nodes[nodes['id'].isin(node_type_list)]
     node_grouping_fields = ['id', 'category']
     if 'in_taxon' in nodes.columns:
@@ -52,51 +64,64 @@ def create_edge_node_types_report(edges_provided_by_values, unique_id_from_nodes
     for node_type_provided_by, node_type_provided_by_values in node_type_group:
         node_type_object = {
             "name": node_type_provided_by,
-            "categories": list(set(node_type_provided_by_values['category'])),
-            "namespaces": list(set(list(set(node_type_provided_by_values['id'].str.split(':').str[0])))),
-            "total_number": len(set(node_type_provided_by_values['id'].tolist())),
+            "categories": col_to_yaml(node_type_provided_by_values['category']),
+            "namespaces": col_to_yaml(get_namespace(node_type_provided_by_values['id'])),
+            "total_number": col_to_yaml(node_type_provided_by_values['id'].tolist()),
             # id that are in nodes file but are not in subject or object from edges file
-            "missing": len(set(node_type_provided_by_values['id']) - (set(edges_provided_by_values['subject'])))
-                       + len(set(node_type_provided_by_values['id']) - (set(edges_provided_by_values['object'])))
+            "missing": series_difference(node_type_provided_by_values['id'], edges_provided_by_values['subject']).size \
+                       + series_difference(node_type_provided_by_values['id'], edges_provided_by_values['object'].size),
+
+            # "missing": len(set(node_type_provided_by_values['id']) - (set(edges_provided_by_values['subject'])))
+            #            + len(set(node_type_provided_by_values['id']) - (set(edges_provided_by_values['object'])))
         }
         if 'in_taxon' in nodes.columns:
-            node_type_object["taxon"] = list(set(node_type_provided_by_values["in_taxon"]))
+            node_type_object["taxon"] = col_to_yaml(node_type_provided_by_values["in_taxon"])
         node_types.append(node_type_object)
     return node_types
 
 
-def create_edges_report(edges, unique_id_from_nodes, nodes):
+def create_edges_report(edges, nodes):
     edges_reports = []
     edges_group = edges.groupby(['provided_by'])[['id', 'object', 'subject', 'predicate', 'category']]
 
     for edges_provided_by, edges_provided_by_values in edges_group:
-        edge_object = create_edge_report(edges_provided_by, edges_provided_by_values, unique_id_from_nodes)
-        edge_object["predicates"] = create_predicate_report(edges_provided_by_values, unique_id_from_nodes)
-        edge_object["node_types"] = create_edge_node_types_report(edges_provided_by_values, unique_id_from_nodes, nodes)
+        edge_object = create_edge_report(edges_provided_by, edges_provided_by_values, nodes["id"])
+        edge_object["predicates"] = create_predicate_report(edges_provided_by_values, nodes["id"])
+        edge_object["node_types"] = create_edge_node_types_report(edges_provided_by_values, nodes)
 
         edges_reports.append(edge_object)
 
     return edges_reports
 
 
+def get_namespace(col: pd.Series) -> pd.Series:
+    return col.str.split(':').str[0]
+
+
+def col_to_yaml(col: pd.Series) -> List[str]:
+    # This probably should have a better name
+    # Convert a column from pandas to data for yaml report
+    return col.drop_duplicates().sort_values().tolist()
+
+
+def get_missing(cols: List[pd.Series], ids: pd.Series) -> List[str]:
+    return list_difference(pd.concat(cols).drop_duplicates().sort_values().tolist(), ids.tolist())
+
+
 def create_nodes_report(nodes: pd.DataFrame) -> List[Dict]:
     node_report = []
-    # node_grouping_fields = set(nodes.columns) & {'id', 'category', 'in_taxon'}
-    node_grouping_fields = intersect_lists(list(nodes.columns), ['id', 'category', 'in_taxon'])
-    # node_grouping_fields = ['id', 'category']
-    # if 'in_taxon' in nodes.columns:
-    #     node_grouping_fields.append('in_taxon')
+    node_grouping_fields = list_intersect(list(nodes.columns), ['id', 'category', 'in_taxon'])
 
     nodes_group = nodes.groupby(['provided_by'])[node_grouping_fields]
     for nodes_provided_by, nodes_provided_by_values in nodes_group:
         node_object = {
             "name": nodes_provided_by,
-            "namespaces": list(set(list(set(nodes_provided_by_values['id'].str.split(':').str[0])))),
-            "categories": list(set(nodes_provided_by_values['category'])),
-            "total_number": len(set(nodes_provided_by_values['id'].tolist())),
+            "namespaces": col_to_yaml(get_namespace(nodes_provided_by_values['id'])),
+            "categories": col_to_yaml(nodes_provided_by_values['category']),
+            "total_number": nodes_provided_by_values['id'].size,
         }
         if 'in_taxon' in nodes.columns:
-            node_object["taxon"] = list(set(nodes_provided_by_values["in_taxon"]))
+            node_object["taxon"] = col_to_yaml(nodes_provided_by_values["in_taxon"])
         node_report.append(node_object)
     return node_report
 
@@ -108,8 +133,22 @@ def ifcols_fillna(df: pd.DataFrame, names_values: dict) -> pd.DataFrame:
     return df
 
 
-def intersect_lists(l1: List, l2: List) -> List:
-    return list(set(l1) & set(l2))
+def list_intersect(a: List, b: List) -> List:
+    a1 = [*dict.fromkeys(a)]  # remove duplicates
+    return [v for v in a1 if v in b]  # maintain oder of list a
+
+
+def series_intersect(a: pd.Series, b: pd.Series) -> pd.Series:
+    return pd.Series(list_intersect(a.to_list(), b.tolist()))
+
+
+def list_difference(a: List, b: List) -> List:
+    a1 = [*dict.fromkeys(a)]  # remove duplicates
+    return [v for v in a1 if v not in b]  # maintain oder of list a
+
+
+def series_difference(a: pd.Series, b: pd.Series) -> pd.Series:
+    return pd.Series(list_difference(a.to_list(), b.tolist()))
 
 
 def create_qc_report(kg: MergedKG) -> Dict:
@@ -119,22 +158,11 @@ def create_qc_report(kg: MergedKG) -> Dict:
     :return: a dictionary representing the QC report
     """
 
-    # nodes = kg.nodes
-    edges = kg.edges
-    dangling_edges = kg.dangling_edges
-
-    # Nodes
-    fill_nodes = {
-        'in_taxon': 'missing taxon',
-        'category': 'missing category'}
-    nodes = ifcols_fillna(kg.nodes, fill_nodes)
-
-    unique_id_from_nodes = nodes["id"]
-
+    nodes = ifcols_fillna(kg.nodes, {'in_taxon': 'missing taxon', 'category': 'missing category'})
     ingest_collection = {
         "nodes": create_nodes_report(nodes),
-        'edges': create_edges_report(edges, unique_id_from_nodes, nodes),
-        'dangling_edges': create_edges_report(dangling_edges, unique_id_from_nodes, nodes)
+        'edges': create_edges_report(kg.edges, nodes),
+        'dangling_edges': create_edges_report(kg.dangling_edges, nodes)
     }
 
     return ingest_collection


### PR DESCRIPTION
This PR splits the qc_utils into simpler functions and removes a lot of confusing "list(set(" operations in favor of descriptive function names and pandas internals. We also attempt to guarantee a predictable order of output in the qc_report but sorting ID's and namespaces before returning.

These changes should make further development easier to debug.