### PR TITLE
Kg stats qc

### DIFF
--- a/cat_merge/qc.py
+++ b/cat_merge/qc.py
@@ -15,16 +15,18 @@ def qc_report(archive_path: str,
               # dangling_edges_path: str = None,
               nodes_file_name: str = None,
               edges_file_name: str = None):
-
     kg = read_kg(archive_path)
     report = create_qc_report(kg)
     del kg
 
-    g = load_graph(name="test_name",
-                   version="0.1",
-                   edges_path=edges_file_name,
-                   nodes_path=nodes_file_name)
-    report["stats"] = create_stats_report(g)
+    if nodes_file_name is None or edges_file_name is None:
+        pass
+    else:
+        g = load_graph(name="test_name",
+                       version="0.1",
+                       edges_path=edges_file_name,
+                       nodes_path=nodes_file_name)
+        report["stats"] = create_stats_report(g)
 
     with open(f"{output_dir}/{output_name}", "w") as report_file:
         yaml.dump(report, report_file)

--- a/cat_merge/qc.py
+++ b/cat_merge/qc.py
@@ -2,7 +2,10 @@ import yaml
 import logging
 
 from cat_merge.file_utils import read_kg
-from cat_merge.qc_utils import create_qc_report
+from cat_merge.qc_utils import create_qc_report, create_stats_report, load_graph
+
+from grape import Graph  # type: ignore
+
 
 def qc_report(archive_path: str,
               output_dir: str,
@@ -12,9 +15,16 @@ def qc_report(archive_path: str,
               # dangling_edges_path: str = None,
               nodes_file_name: str = None,
               edges_file_name: str = None):
-    kg = read_kg(archive_path)
 
-    qc_report = create_qc_report(kg)
+    kg = read_kg(archive_path)
+    report = create_qc_report(kg)
+    del kg
+
+    g = load_graph(name="test_name",
+                   version="0.1",
+                   edges_path=edges_file_name,
+                   nodes_path=nodes_file_name)
+    report["stats"] = create_stats_report(g)
 
     with open(f"{output_dir}/{output_name}", "w") as report_file:
-        yaml.dump(qc_report, report_file)
+        yaml.dump(report, report_file)

--- a/cat_merge/qc_utils.py
+++ b/cat_merge/qc_utils.py
@@ -16,8 +16,8 @@ def create_edge_report(edges_provided_by, edges_provided_by_values, unique_id_fr
         "categories": col_to_yaml(edges_provided_by_values['category']),
         "total_number": edges_provided_by_values['id'].size,
         # unique subjects and objects in edges but not in unique id nodes file
-        "missing": get_missing(
-            [edges_provided_by_values['subject'], edges_provided_by_values['object']], unique_id_from_nodes),
+        "missing": len(get_missing(
+            [edges_provided_by_values['subject'], edges_provided_by_values['object']], unique_id_from_nodes)),
         # "missing": list_difference(pd.concat(
         #     [edges_provided_by_values['subject'], edges_provided_by_values['object']]
         # ).drop_duplicates().sort_values().tolist(), unique_id_from_nodes.tolist()),
@@ -96,7 +96,7 @@ def create_edges_report(edges, nodes):
 
 
 def get_namespace(col: pd.Series) -> pd.Series:
-    return col if len(col) is 0 else col.str.split(':').str[0]
+    return col if len(col) == 0 else col.str.split(':').str[0]
 
 
 def col_to_yaml(col: pd.Series) -> List[str]:

--- a/cat_merge/qc_utils.py
+++ b/cat_merge/qc_utils.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from grape import Graph  # type: ignore
 
 from cat_merge.model.merged_kg import MergedKG
 from typing import Dict, List
@@ -95,7 +96,7 @@ def create_edges_report(edges, nodes):
 
 
 def get_namespace(col: pd.Series) -> pd.Series:
-    return col.str.split(':').str[0]
+    return col if len(col) is 0 else col.str.split(':').str[0]
 
 
 def col_to_yaml(col: pd.Series) -> List[str]:
@@ -148,7 +149,53 @@ def list_difference(a: List, b: List) -> List:
 
 
 def series_difference(a: pd.Series, b: pd.Series) -> pd.Series:
-    return pd.Series(list_difference(a.to_list(), b.tolist()))
+    return pd.Series(list_difference(a.to_list(), b.tolist()), dtype=str)
+
+
+def load_graph(name: str, version: str, edges_path: str,
+               nodes_path: str) -> Graph:
+    """
+    Load a graph with Ensmallen (from grape).
+    :param name: OBO name
+    :param version: OBO version
+    :param edges_path: path to edgefile
+    :param nodes_path: path to nodefile
+    :return: ensmallen Graph object
+    """
+
+    loaded_graph = Graph.from_csv(name=f"{name}_version_{version}",
+                                  edge_path=edges_path,
+                                  sources_column="subject",
+                                  destinations_column="object",
+                                  edge_list_header=True,
+                                  edge_list_separator="\t",
+                                  node_path=nodes_path,
+                                  nodes_column="id",
+                                  node_list_header=True,
+                                  node_list_separator="\t",
+                                  directed=False,
+                                  verbose=True
+                                  )
+
+    return loaded_graph
+
+
+def create_stats_report(g: Graph) -> List[Dict]:
+    node_count = g.get_number_of_nodes()
+    edge_count = g.get_number_of_edges()
+    connected_components = g.get_number_of_connected_components()
+    singleton_count = g.get_number_of_singleton_nodes()
+    max_node_degree = g.get_maximum_node_degree()
+    mean_node_degree = g.get_node_degrees_mean()
+
+    graph_stats = {"Nodes": node_count,
+                   "Edges": edge_count,
+                   "ConnectedComponents": connected_components,
+                   "Singletons": singleton_count,
+                   "MaxNodeDegree": max_node_degree,
+                   "MeanNodeDegree": "{:.2f}".format(mean_node_degree)}
+
+    return [graph_stats]
 
 
 def create_qc_report(kg: MergedKG) -> Dict:


### PR DESCRIPTION
This PR fixes some issues where the QC report lost some information on the nodes in the edges reports. I have also incorporated the stats calculated from kg-obo stats.py. Due to the way the grape Graph library imports graphs the additional stats are only performed when qc_report is run with node and edge files specified.