### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cat-merge"
-version = "0.1.17"
+version = "0.1.18"
 description = ""
 authors = [
     "Monarch Initiative <info@monarchinitiative.org>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = "^3.10"
 click = "^8"
 pandas = "^1.4.2"
 mkdocs = "^1.3.0"


### PR DESCRIPTION
cat-merge requires python >= 3.10, as it turns out. 
may as well update this in the pyproject.toml