### PR TITLE
Use comment characters when reading SSSOM files but not for reading kgx files

### DIFF
--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -30,7 +30,9 @@ def get_files(filepath: str, nodes_match: str = "_nodes", edges_match: str = "_e
     return node_files, edge_files
 
 
-def read_dfs(files: List[str], add_source_col: Optional[str] = "provided_by") -> List[pd.DataFrame]:
+def read_dfs(files: List[str],
+             add_source_col: Optional[str] = "provided_by",
+             comment_character: str = None) -> List[pd.DataFrame]:
     """
     Read a list of files into dataframes.
 
@@ -43,7 +45,7 @@ def read_dfs(files: List[str], add_source_col: Optional[str] = "provided_by") ->
     """
     dataframes = []
     for file in files:
-        dataframes.append(read_df(file, add_source_col, Path(file).stem))
+        dataframes.append(read_df(file, add_source_col, Path(file).stem, comment_character=comment_character))
     return dataframes
 
 
@@ -68,7 +70,8 @@ def read_tar_dfs(tar: tarfile.TarFile, type_name, add_source_col: str = "provide
 
 def read_df(fh: Union[str, IO[bytes]],
             add_source_col: Optional[str] = "provided_by",
-            source_col_value: Optional[str] = None) -> pd.DataFrame:
+            source_col_value: Optional[str] = None,
+            comment_character: str = None) -> pd.DataFrame:
     """
     Read a file into a dataframe.
 
@@ -76,11 +79,12 @@ def read_df(fh: Union[str, IO[bytes]],
         fh (str, io.TextIOWrapper): File handle.
         add_source_col (str, optional): Name of column to add to the dataframe with the name of the file.
         source_col_value (Any, optional): Value to add to the source column.
+        comment_character (str, optional): Character to ignore lines starting with, or anything after.
 
     Returns:
         pandas.DataFrame: Dataframe.
     """
-    df = pd.read_csv(fh, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE, comment='#')
+    df = pd.read_csv(fh, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE, comment=comment_character)
     if add_source_col is not None:
         df[add_source_col] = source_col_value
     return df

--- a/cat_merge/merge.py
+++ b/cat_merge/merge.py
@@ -72,7 +72,7 @@ Merging KG files...
 
     mapping_dfs = []
     if mappings is not None:
-        mapping_dfs = read_dfs(mappings, add_source_col=None)
+        mapping_dfs = read_dfs(mappings, add_source_col=None, comment_character="#")
 
     print("Merging...")
     kg, qc = merge_kg(node_dfs=node_dfs, edge_dfs=edge_dfs, mapping_dfs=mapping_dfs)

--- a/cat_merge/merge.py
+++ b/cat_merge/merge.py
@@ -45,7 +45,7 @@ Merging KG files...
   mappings: {mappings}
   output_dir: {output_dir}
 """)
-    if nodes is None != (edges is None) or source is None == (nodes is None):
+    if source is None and (nodes is None or edges is None):
         raise ValueError("Wrong attributes: must specify both nodes & edges or source")
 
     if source is not None and (nodes or edges):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cat-merge"
-version = "0.1.18"
+version = "0.1.19"
 description = ""
 authors = [
     "Monarch Initiative <info@monarchinitiative.org>",


### PR DESCRIPTION
As we're being less restrictive about loading phenio nodes/edges, some are coming in with #s in the id,subject,object fields. With the comment character set in pandas, this ignores the rest of the line. We can't just get rid of using comment characters in read_df though, because SSSOM files need it. Now it will be used conditionally.

