### PR TITLE
Change default data type for qc report to list

### DIFF
--- a/cat_merge/qc_utils.py
+++ b/cat_merge/qc_utils.py
@@ -369,7 +369,7 @@ def get_difference(a: Union[List, pd.Series], b: Union[List, pd.Series]) -> Unio
     return s if type(a) is list else pd.Series(s, dtype=a.dtype, name=a.name)
 
 
-def create_qc_report(kg: MergedKG, qc: MergeQC, data_type: type = dict, group_by: str = "provided_by") -> Dict:
+def create_qc_report(kg: MergedKG, qc: MergeQC, data_type: type = list, group_by: str = "provided_by") -> Dict:
     """
     interface for generating qc report from merged kg
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cat-merge"
-version = "0.1.20"
+version = "0.1.21"
 description = ""
 authors = [
     "Monarch Initiative <info@monarchinitiative.org>",

--- a/tests/unit/qc_utils/test_create_qc_report.py
+++ b/tests/unit/qc_utils/test_create_qc_report.py
@@ -21,13 +21,13 @@ def qc_report_expected_dict() -> Dict:
     return report_values
 
 
-def test_create_qc_report_defaults(kg_1, empty_qc, qc_report_expected_dict):
+def test_create_qc_report_defaults(kg_1, empty_qc, qc_report_expected_list):
     test_report = create_qc_report(kg_1, empty_qc)
 
     assert type(test_report) is dict
     assert len(test_report) == 5
-    check_report_data(test_report.keys(), qc_report_expected_dict.keys())
-    check_report_data(test_report.values(), qc_report_expected_dict.values())
+    check_report_data(test_report.keys(), qc_report_expected_list.keys())
+    check_report_data(test_report.values(), qc_report_expected_list.values())
 
 
 def test_create_qc_report_list(kg_1, empty_qc, qc_report_expected_list):


### PR DESCRIPTION
I thought I'd be doing a rollback, but now I see how nicely @amc-corey-cox set this up to support both lists and dicts. I just changed the default back to list, since that's what the web side still requires.