### PR TITLE
`nan` gene name should pass through merge unaffected

### DIFF
--- a/cat_merge/file_utils.py
+++ b/cat_merge/file_utils.py
@@ -84,7 +84,14 @@ def read_df(fh: Union[str, IO[bytes]],
     Returns:
         pandas.DataFrame: Dataframe.
     """
-    df = pd.read_csv(fh, sep="\t", dtype="string", lineterminator="\n", quoting=csv.QUOTE_NONE, comment=comment_character)
+    df = pd.read_csv(fh,
+                     sep="\t",
+                     dtype="string",
+                     lineterminator="\n",
+                     quoting=csv.QUOTE_NONE,
+                     comment=comment_character,
+                     keep_default_na=False,
+                     na_values=[''])
     if add_source_col is not None:
         df[add_source_col] = source_col_value
     return df

--- a/cat_merge/merge_utils.py
+++ b/cat_merge/merge_utils.py
@@ -41,7 +41,7 @@ def clean_nodes(nodes: DataFrame) -> DataFrame:
     Returns:
         pandas.DataFrame: Dataframe of nodes with duplicates dropped
     """
-    nodes.drop_duplicates(inplace=True)
+    nodes.drop_duplicates(inplace=True, subset=['id'], keep='first')
     return nodes
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cat-merge"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = [
     "Monarch Initiative <info@monarchinitiative.org>",

--- a/tests/integration/test_merge.py
+++ b/tests/integration/test_merge.py
@@ -11,10 +11,10 @@ def nodes_and_edges() -> Tuple[List[DataFrame], List[DataFrame]]:
     edges = []
 
     gene_nodes = u"""\
-    id      category xref
-    Gene:1  Gene     NCBI:10
-    Gene:2  Gene     ZFIN:123 
-    Gene:3  Gene     HGNC:11  
+    id      category xref   symbol
+    Gene:1  Gene     NCBI:10    nan
+    Gene:2  Gene     ZFIN:123
+    Gene:3  Gene     HGNC:11
     Gene:4  Gene 
     Gene:4  Gene 
     """
@@ -86,3 +86,8 @@ def test_merge_kg_dangling_edge_count(nodes_and_edges):
 def test_merge_kg_duplicate_node_count(nodes_and_edges):
     kg, qc = merge_kg(node_dfs=nodes_and_edges[0], edge_dfs=nodes_and_edges[1])
     assert(len(qc.duplicate_nodes) == 2)
+
+def test_merged_node_name(nodes_and_edges):
+    kg, qc = merge_kg(node_dfs=nodes_and_edges[0], edge_dfs=nodes_and_edges[1])
+    gene_1_name = kg.nodes[kg.nodes.id == 'Gene:1'].name.values[0]
+    assert(gene_1_name == 'nan', "Gene:1 should have name 'nan' and not be replaced by an empty string")

--- a/tests/integration/test_merge.py
+++ b/tests/integration/test_merge.py
@@ -11,12 +11,12 @@ def nodes_and_edges() -> Tuple[List[DataFrame], List[DataFrame]]:
     edges = []
 
     gene_nodes = u"""\
-    id      category xref   symbol
-    Gene:1  Gene     NCBI:10    nan
-    Gene:2  Gene     ZFIN:123
-    Gene:3  Gene     HGNC:11
-    Gene:4  Gene 
-    Gene:4  Gene 
+    id      category symbol xref   
+    Gene:1  Gene     nan    NCBI:10 
+    Gene:2  Gene     fgf    ZFIN:123
+    Gene:3  Gene     pax    HGNC:11
+    Gene:4  Gene     foo
+    Gene:4  Gene     bar
     """
     nodes.append(string_df(gene_nodes))
 
@@ -89,5 +89,5 @@ def test_merge_kg_duplicate_node_count(nodes_and_edges):
 
 def test_merged_node_name(nodes_and_edges):
     kg, qc = merge_kg(node_dfs=nodes_and_edges[0], edge_dfs=nodes_and_edges[1])
-    gene_1_name = kg.nodes[kg.nodes.id == 'Gene:1'].name.values[0]
-    assert(gene_1_name == 'nan', "Gene:1 should have name 'nan' and not be replaced by an empty string")
+    gene_1_symbol = kg.nodes[kg.nodes.id == 'Gene:1'].symbol.values[0]
+    assert gene_1_symbol == 'nan', "Gene:1 should have name 'nan' and not be replaced by an empty string"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,9 +10,9 @@ from pandas.core.frame import DataFrame
 # Borrowed from https://stackoverflow.com/questions/58771331/cleanly-hard-code-a-pandas-dataframe-into-a-python-script
 def string_df(data: str, index_column_is_id=True):
     if index_column_is_id:
-        df = pd.read_csv(StringIO(data), sep=r"\s+", engine='python')
+        df = pd.read_csv(StringIO(data), sep=r"\s+", engine='python', keep_default_na=False, na_values=[''])
     else:
-        df = pd.read_csv(StringIO(data), sep=r"\s+", engine='python')
+        df = pd.read_csv(StringIO(data), sep=r"\s+", engine='python', keep_default_na=False, na_values=[''])
     return df
 
 


### PR DESCRIPTION
Initially added a unit test to confirm that cat-merge is responsible for mangling the `nan` gene, will debug further (and maybe add more tests) to confirm where that's happening. 